### PR TITLE
Provide default implementation of validateString protocol

### DIFF
--- a/Source/CardExpirationDateInputValidator.swift
+++ b/Source/CardExpirationDateInputValidator.swift
@@ -14,10 +14,6 @@ public struct CardExpirationDateInputValidator: Validatable {
         self.validation = validation
     }
 
-    public func validateString(string: String) -> Bool {
-        return self.validateReplacementString(nil, usingFullString: string, inRange: nil)
-    }
-
     public func validateReplacementString(replacementString: String?, usingFullString fullString: String?, inRange range: NSRange?, exhaustive: Bool = false) -> Bool {
         let baseInputValidator = InputValidator(validation: self.validation)
         var valid = baseInputValidator.validateReplacementString(replacementString, usingFullString: fullString, inRange: range)

--- a/Source/DecimalInputValidator.swift
+++ b/Source/DecimalInputValidator.swift
@@ -8,10 +8,6 @@ public struct DecimalInputValidator: Validatable {
         self.validation = validation
     }
 
-    public func validateString(string: String) -> Bool {
-        return self.validateReplacementString(nil, usingFullString: string, inRange: nil)
-    }
-
     public func validateReplacementString(replacementString: String?, usingFullString fullString: String?, inRange range: NSRange?, exhaustive: Bool = false) -> Bool {
         let baseInputValidator = InputValidator(validation: self.validation)
         var valid = baseInputValidator.validateReplacementString(replacementString, usingFullString: fullString, inRange: range)

--- a/Source/InputValidator.swift
+++ b/Source/InputValidator.swift
@@ -8,10 +8,6 @@ public struct InputValidator: Validatable {
         self.validation = validation
     }
 
-    public func validateString(string: String) -> Bool {
-        return self.validateReplacementString(nil, usingFullString: string, inRange: nil, exhaustive: true)
-    }
-
     public func validateReplacementString(replacementString: String?, usingFullString fullString: String?, inRange range: NSRange?, exhaustive: Bool = false) -> Bool {
         let text = fullString ?? ""
         var evaluatedString = text

--- a/Source/IntegerInputValidator.swift
+++ b/Source/IntegerInputValidator.swift
@@ -8,10 +8,6 @@ public struct IntegerInputValidator: Validatable {
         self.validation = validation
     }
 
-    public func validateString(string: String) -> Bool {
-        return self.validateReplacementString(nil, usingFullString: string, inRange: nil)
-    }
-
     public func validateReplacementString(replacementString: String?, usingFullString fullString: String?, inRange range: NSRange?, exhaustive: Bool = false) -> Bool {
         let baseInputValidator = InputValidator(validation: self.validation)
         var valid = baseInputValidator.validateReplacementString(replacementString, usingFullString: fullString, inRange: range)

--- a/Source/NameInputValidator.swift
+++ b/Source/NameInputValidator.swift
@@ -8,10 +8,6 @@ public struct NameInputValidator: Validatable {
         self.validation = validation
     }
 
-    public func validateString(string: String) -> Bool {
-        return self.validateReplacementString(nil, usingFullString: string, inRange: nil)
-    }
-
     public func validateReplacementString(replacementString: String?, usingFullString fullString: String?, inRange range: NSRange?, exhaustive: Bool = false) -> Bool {
         let baseInputValidator = InputValidator(validation: self.validation)
         var valid = baseInputValidator.validateReplacementString(replacementString, usingFullString: fullString, inRange: range)

--- a/Source/Validatable.swift
+++ b/Source/Validatable.swift
@@ -9,3 +9,9 @@ public protocol Validatable {
     // will cause the validation to fail, meanwhile making exhaustive be false, will cause the validation to succeed.
     func validateReplacementString(replacementString: String?, usingFullString fullString: String?, inRange range: NSRange?, exhaustive: Bool ) -> Bool
 }
+
+extension Validatable {
+    public func validateString(string: String) -> Bool {
+        return self.validateReplacementString(nil, usingFullString: string, inRange: nil, exhaustive: true)
+    }
+}


### PR DESCRIPTION
The implementation of `validateString` is pretty much generic and repetitive, thankfully Swift 2 allows you to introduce default implementations using protocol extensions.

I :heart: Swift.
