### PR TITLE
Simple emoji fix (#21)

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		140491C51EA8B07900E159EA /* InputValidatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140491C41EA8B07900E159EA /* InputValidatableTests.swift */; };
 		140D80AC1C469D4D00F5BEAF /* RequiredInputValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140D80AB1C469D4D00F5BEAF /* RequiredInputValidatorTests.swift */; };
 		142F80A11EA8A4B500EA341B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142F80A01EA8A4B500EA341B /* AppDelegate.swift */; };
 		142F80A31EA8A4B500EA341B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142F80A21EA8A4B500EA341B /* ViewController.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		140491C41EA8B07900E159EA /* InputValidatableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputValidatableTests.swift; sourceTree = "<group>"; };
 		140D80AB1C469D4D00F5BEAF /* RequiredInputValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequiredInputValidatorTests.swift; sourceTree = "<group>"; };
 		142F809E1EA8A4B500EA341B /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		142F80A01EA8A4B500EA341B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 		146D72AF1AB782920058798C /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				140491C41EA8B07900E159EA /* InputValidatableTests.swift */,
 				1449FDAA1C395D93002A8F35 /* CardExpirationDateInputValidatorTests.swift */,
 				1449FDAB1C395D93002A8F35 /* DecimalInputValidatorTests.swift */,
 				140D80AB1C469D4D00F5BEAF /* RequiredInputValidatorTests.swift */,
@@ -361,6 +364,7 @@
 			files = (
 				1449FDAD1C395D93002A8F35 /* DecimalInputValidatorTests.swift in Sources */,
 				1449FDAC1C395D93002A8F35 /* CardExpirationDateInputValidatorTests.swift in Sources */,
+				140491C51EA8B07900E159EA /* InputValidatableTests.swift in Sources */,
 				140D80AC1C469D4D00F5BEAF /* RequiredInputValidatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -548,6 +552,7 @@
 				142F80AE1EA8A4B500EA341B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		146D728E1AB782920058798C /* Build configuration list for PBXProject "Demo" */ = {
 			isa = XCConfigurationList;

--- a/Sources/InputValidatable.swift
+++ b/Sources/InputValidatable.swift
@@ -38,18 +38,10 @@ extension InputValidatable {
     }
 
     public func composedString(_ replacementString: String?, fullString: String?, inRange range: NSRange?) -> String {
-        var composedString = fullString ?? ""
-
-        if let replacementString = replacementString, let range = range {
-            let index = composedString.characters.index(composedString.startIndex, offsetBy: range.location)
-            if range.location == composedString.characters.count {
-                composedString.insert(contentsOf: replacementString.characters, at: index)
-            } else {
-                composedString = (composedString as NSString).replacingCharacters(in: range, with: replacementString)
-            }
-            return composedString
+        if let replacementString = replacementString, let range = range, let fullString = fullString as NSString? {
+            return fullString.replacingCharacters(in: range, with: replacementString)
         }
 
-        return composedString
+        return fullString ?? ""
     }
 }

--- a/Tests/CardExpirationDateInputValidatorTests.swift
+++ b/Tests/CardExpirationDateInputValidatorTests.swift
@@ -10,31 +10,31 @@ class CardExpirationDateInputValidatorTests: XCTestCase {
 
         // 1st character: First character can be 0, 1
         let oneCharacter = ""
-        let oneCharacterLenght = oneCharacter.characters.count
-        XCTAssertTrue(validator.validateReplacementString("0", fullString: "", inRange: NSRange(location: oneCharacterLenght, length: oneCharacterLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString("1", fullString: "", inRange: NSRange(location: oneCharacterLenght, length: oneCharacterLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString("2", fullString: "", inRange: NSRange(location: oneCharacterLenght, length: oneCharacterLenght + 1)))
+        let oneCharacterLength = oneCharacter.characters.count
+        XCTAssertTrue(validator.validateReplacementString("0", fullString: "", inRange: NSRange(location: oneCharacterLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString("1", fullString: "", inRange: NSRange(location: oneCharacterLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString("2", fullString: "", inRange: NSRange(location: oneCharacterLength, length: 0)))
 
         // 2nd character: The second character composed with the first one should be equal or less than 12
         let secondCharacter = "1"
-        let secondCharacterLenght = secondCharacter.characters.count
-        XCTAssertTrue(validator.validateReplacementString("1", fullString: "0", inRange: NSRange(location: secondCharacterLenght, length: secondCharacterLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString("2", fullString: "1", inRange: NSRange(location: secondCharacterLenght, length: secondCharacterLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString("3", fullString: "1", inRange: NSRange(location: secondCharacterLenght, length: secondCharacterLenght + 1)))
+        let secondCharacterLength = secondCharacter.characters.count
+        XCTAssertTrue(validator.validateReplacementString("1", fullString: "0", inRange: NSRange(location: secondCharacterLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString("2", fullString: "1", inRange: NSRange(location: secondCharacterLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString("3", fullString: "1", inRange: NSRange(location: secondCharacterLength, length: 0)))
 
         // 3rd character: The third character is the '\'
         let thirdCharacter = "MM"
-        let thirdCharacterLenght = thirdCharacter.characters.count
-        XCTAssertFalse(validator.validateReplacementString("0", fullString: "12", inRange: NSRange(location: thirdCharacterLenght, length: thirdCharacterLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString("/", fullString: "12", inRange: NSRange(location: thirdCharacterLenght, length: thirdCharacterLenght + 1)))
+        let thirdCharacterLength = thirdCharacter.characters.count
+        XCTAssertFalse(validator.validateReplacementString("0", fullString: "12", inRange: NSRange(location: thirdCharacterLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString("/", fullString: "12", inRange: NSRange(location: thirdCharacterLength, length: 0)))
 
         // 4th character: The fourth character has to be higher than the decimal of the current year.
         // For example if the current year is 2015, then the fourth character has to be equal or higher than 1
         let fourthCharacter = "MM/"
-        let fourthCharacterLenght = fourthCharacter.characters.count
-        XCTAssertFalse(validator.validateReplacementString("0", fullString: "12/", inRange: NSRange(location: fourthCharacterLenght, length: fourthCharacterLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString("1", fullString: "12/", inRange: NSRange(location: fourthCharacterLenght, length: fourthCharacterLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString("2", fullString: "12/", inRange: NSRange(location: fourthCharacterLenght, length: fourthCharacterLenght + 1)))
+        let fourthCharacterLength = fourthCharacter.characters.count
+        XCTAssertFalse(validator.validateReplacementString("0", fullString: "12/", inRange: NSRange(location: fourthCharacterLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString("1", fullString: "12/", inRange: NSRange(location: fourthCharacterLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString("2", fullString: "12/", inRange: NSRange(location: fourthCharacterLength, length: 0)))
 
         let date = Date()
         let calendar = Calendar.current
@@ -47,9 +47,9 @@ class CardExpirationDateInputValidatorTests: XCTestCase {
         // 5th character: The fifth character composed with the fourth character should be equal or higher than
         // the decimal of the current year
         let fifthCharacter = "MM/1"
-        let fifthCharacterLenght = fifthCharacter.characters.count
-        XCTAssertFalse(validator.validateReplacementString(previousYear, fullString: "12/1", inRange: NSRange(location: fifthCharacterLenght, length: fifthCharacterLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString(currentYear, fullString: "12/1", inRange: NSRange(location: fifthCharacterLenght, length: fifthCharacterLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString(nextYear, fullString: "12/1", inRange: NSRange(location: fifthCharacterLenght, length: fifthCharacterLenght + 1)))
+        let fifthCharacterLength = fifthCharacter.characters.count
+        XCTAssertFalse(validator.validateReplacementString(previousYear, fullString: "12/1", inRange: NSRange(location: fifthCharacterLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString(currentYear, fullString: "12/1", inRange: NSRange(location: fifthCharacterLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString(nextYear, fullString: "12/1", inRange: NSRange(location: fifthCharacterLength, length: 0)))
     }
 }

--- a/Tests/DecimalInputValidatorTests.swift
+++ b/Tests/DecimalInputValidatorTests.swift
@@ -16,34 +16,34 @@ class DecimalInputValidatorTests: XCTestCase {
 
         // 1st character
         var fullString = ""
-        var fullStringLenght = fullString.characters.count
-        XCTAssertTrue(validator.validateReplacementString("0", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
+        var fullStringLength = fullString.characters.count
+        XCTAssertTrue(validator.validateReplacementString("0", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
 
         // 2nd character:
         fullString = "1"
-        fullStringLenght = fullString.characters.count
-        XCTAssertTrue(validator.validateReplacementString("1", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertTrue(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
+        fullStringLength = fullString.characters.count
+        XCTAssertTrue(validator.validateReplacementString("1", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertTrue(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
 
         // 3rd character:
         fullString = "1,"
-        fullStringLenght = fullString.characters.count
-        XCTAssertTrue(validator.validateReplacementString("1", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
+        fullStringLength = fullString.characters.count
+        XCTAssertTrue(validator.validateReplacementString("1", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
 
         // 3rd character alternative:
         fullString = "1."
-        fullStringLenght = fullString.characters.count
-        XCTAssertTrue(validator.validateReplacementString("1", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
-        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLenght, length: fullStringLenght + 1)))
+        fullStringLength = fullString.characters.count
+        XCTAssertTrue(validator.validateReplacementString("1", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString(",", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString(".", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
+        XCTAssertFalse(validator.validateReplacementString("/", fullString: fullString, inRange: NSRange(location: fullStringLength, length: 0)))
     }
 }

--- a/Tests/InputValidatableTests.swift
+++ b/Tests/InputValidatableTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import Validation
+import InputValidator
+import Foundation
+
+class InputValidatableTests: XCTestCase {
+    func testComposedStringStrings() {
+        var validation = Validation()
+        validation.maximumLength = 5
+        let inputValidator = InputValidator(validation: validation)
+        let result = inputValidator.composedString("a", fullString: "n", inRange: NSRange(location: 1, length: 0))
+        XCTAssertEqual(result, "na")
+    }
+
+    func testComposedStringEmoji() {
+        var validation = Validation()
+        validation.maximumLength = 5
+        let inputValidator = InputValidator(validation: validation)
+        let result = inputValidator.composedString("👌", fullString: "💕", inRange: NSRange(location: 2, length: 0))
+        XCTAssertEqual(result, "💕👌")
+    }
+}

--- a/Tests/RequiredInputValidatorTests.swift
+++ b/Tests/RequiredInputValidatorTests.swift
@@ -9,4 +9,9 @@ class RequiredInputValidatorTests: XCTestCase {
         XCTAssertTrue(validator.validateString("12/12"))
         XCTAssertFalse(validator.validateString(""))
     }
+    
+    func testEmojis() {
+        let validator = RequiredInputValidator()
+        XCTAssertTrue(validator.validateString("😀😇"))
+    }
 }

--- a/Tests/RequiredInputValidatorTests.swift
+++ b/Tests/RequiredInputValidatorTests.swift
@@ -9,9 +9,4 @@ class RequiredInputValidatorTests: XCTestCase {
         XCTAssertTrue(validator.validateString("12/12"))
         XCTAssertFalse(validator.validateString(""))
     }
-    
-    func testEmojis() {
-        let validator = RequiredInputValidator()
-        XCTAssertTrue(validator.validateString("😀😇"))
-    }
 }


### PR DESCRIPTION
Moved from https://github.com/3lvis/InputValidator/pull/21

* Simple emoji fix

* Fix spelling error in test code

* Fix tests to use correct range length (0)

When a character is added to a UITextField, the range it provides is zero-length, to indicate that this is insertion and not replacement.

* Emoji test